### PR TITLE
WIP: Add context to errors

### DIFF
--- a/examples/context.rs
+++ b/examples/context.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::num::ParseIntError;
 use std::path::{Path, PathBuf};
 
-use quick_error::{Context, ResultExt};
+use quick_error::ResultExt;
 
 quick_error! {
     #[derive(Debug)]

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -1,0 +1,48 @@
+#[macro_use(quick_error)] extern crate quick_error;
+
+use std::io::{self, stderr, Read, Write};
+use std::fs::File;
+use std::env;
+use std::num::ParseIntError;
+use std::path::{Path, PathBuf};
+
+use quick_error::{Context, ResultExt};
+
+quick_error! {
+    #[derive(Debug)]
+    pub enum Error {
+        NoFileName {
+            description("no file name specified")
+        }
+        Io(err: io::Error, path: PathBuf) {
+            display("could not read file {:?}: {}", path, err)
+            context(path: &'a Path, err: io::Error)
+                -> (err, path.to_path_buf())
+        }
+        Parse(err: ParseIntError, path: PathBuf) {
+            display("could not parse file {:?}: {}", path, err)
+            context(path: &'a Path, err: ParseIntError)
+                -> (err, path.to_path_buf())
+        }
+    }
+}
+
+fn parse_file() -> Result<u64, Error> {
+    let fname = try!(env::args().skip(1).next().ok_or(Error::NoFileName));
+    let fname = Path::new(&fname);
+    let mut file = try!(File::open(fname).context(fname));
+    let mut buf = String::new();
+    try!(file.read_to_string(&mut buf).context(fname));
+    Ok(try!(buf.parse().context(fname)))
+}
+
+fn main() {
+    match parse_file() {
+        Ok(val) => {
+            println!("Read: {}", val);
+        }
+        Err(e) => {
+            writeln!(&mut stderr(), "Error: {}", e).ok();
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,10 +197,63 @@
 //! }
 //! ```
 //!
-//! All forms of `from`, `display`, `description`, `cause` clauses can be
-//! combined and put in arbitrary order. Only `from` may be used multiple times
-//! in single variant of enumeration. Docstrings are also okay.
-//! Empty braces can be omitted as of quick_error 0.1.3.
+//! Since quick-error 1.1 we also have a `context` declaration, which is
+//! similar to (the longest form of) `from`, but allows adding some context to
+//! the error. We need a longer example to demonstrate this:
+//!
+//! ```rust
+//! # #[macro_use] extern crate quick_error;
+//! # use std::io;
+//! # use std::fs::File;
+//! # use std::path::{Path, PathBuf};
+//! #
+//! use quick_error::ResultExt;
+//!
+//! quick_error! {
+//!     #[derive(Debug)]
+//!     pub enum Error {
+//!         File(filename: PathBuf, err: io::Error) {
+//!             context(path: &'a Path, err: io::Error)
+//!                 -> (path.to_path_buf(), err)
+//!         }
+//!     }
+//! }
+//!
+//! fn openfile(path: &Path) -> Result<(), Error> {
+//!     try!(File::open(path).context(path));
+//!
+//!     // If we didn't have context, the line above would be written as;
+//!     //
+//!     // try!(File::open(path)
+//!     //     .map_err(|err| Error::File(path.to_path_buf(), err)));
+//!
+//!     Ok(())
+//! }
+//!
+//! # fn main() {
+//! #     openfile(Path::new("/etc/somefile")).ok();
+//! # }
+//! ```
+//!
+//! Each `context(a: A, b: B)` clause implements
+//! `From<Context<A, B>> for Error`. Which means multiple `context` clauses
+//! are a subject to the normal coherence rules. Unfortunately, we can't
+//! provide full support of generics for the context, but you may either use a
+//! lifetime `'a` for references or `AsRef<Type>` (the latter means `A:
+//! AsRef<Type>`, and `Type` must be concrete). It's also occasionally useful
+//! to use a tuple as a type of the first argument.
+//!
+//! You also need to `use quick_error::ResultExt` extension trait to get
+//! working `.context()` method.
+//!
+//! More info on context in [this article](http://bit.ly/1PsuxDt).
+//!
+//! All forms of `from`, `display`, `description`, `cause`, and `context`
+//! clauses can be combined and put in arbitrary order. Only `from` and
+//! `context` can be used multiple times in single variant of enumeration.
+//! Docstrings are also okay.  Empty braces can be omitted as of quick_error
+//! 0.1.3.
+//!
 //!
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -668,8 +668,11 @@ macro_rules! quick_error {
         { context($cvar:ident: $ctyp:ty, $fvar:ident: $ftyp:ty)
             -> ($( $texpr:expr ),*) $( $tail:tt )*}
     ) => {
-        impl<'a> From<Context<$ctyp, $ftyp>> for $name {
-            fn from(Context($cvar, $fvar): Context<$ctyp, $ftyp>) -> $name {
+        impl<'a> From<$crate::Context<$ctyp, $ftyp>> for $name {
+            fn from(
+                $crate::Context($cvar, $fvar): $crate::Context<$ctyp, $ftyp>)
+                -> $name
+            {
                 $name::$item($( $texpr ),*)
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -776,6 +776,7 @@ macro_rules! quick_error {
 }
 
 
+#[derive(Debug)]
 pub struct Context<X, E>(pub X, pub E);
 
 pub trait ResultExt<T, E> {
@@ -998,5 +999,15 @@ mod test {
         }
         assert_eq!(format!("{}", parse_int("12.5").unwrap_err()),
             r#"Int error "12.5": invalid digit found in string"#);
+    }
+
+    #[test]
+    fn debug_context() {
+        fn parse_int(s: &str) -> i32 {
+            s.parse().context(s).unwrap()
+        }
+        assert_eq!(parse_int("12"), 12);
+        assert_eq!(format!("{:?}", "x".parse::<i32>().context("x")),
+            r#"Err(Context("x", ParseIntError { kind: InvalidDigit }))"#);
     }
 }


### PR DESCRIPTION
This issue was already brought as #4. This one tracks current implementation in branch `context2`.

You can try it with:

```
[dependencies.quick-error]
git = "http://github.com/tailhook/quick-error"
branch = "context2"
```

[Example usage](https://github.com/tailhook/quick-error/blob/context2/examples/context.rs)

Todo list:
- [x] Basic support for tuple enum members
- [x] Experiment with generics (`AsRef<X>` only, can we provide arbitrary generics somehow?)
- [x] Fix support for struct enum members
- [x] Add unit tests
- [x] Add documentation
- [x] Add `Debug` implementation, make sure that `.unwrap()` and `.expect` work
