### PR TITLE
Use edition = "2018"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ description = """
 """
 license = "MIT/Apache-2.0"
 version = "1.2.2"
+edition = "2018"
 keywords = ["macro", "error", "type", "enum"]
 authors = ["Paul Colomiets <paul@colomiets.name>", "Colin Kiegel <kiegel@gmx.de>"]
 homepage = "http://github.com/tailhook/quick-error"

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -28,11 +28,11 @@ quick_error! {
 }
 
 fn parse_file() -> Result<u64, Error> {
-    let fname = try!(env::args().skip(1).next().ok_or(Error::NoFileName));
+    let fname = env::args().skip(1).next().ok_or(Error::NoFileName)?;
     let fname = Path::new(&fname);
-    let mut file = try!(File::open(fname).context(fname));
+    let mut file = File::open(fname).context(fname)?;
     let mut buf = String::new();
-    try!(file.read_to_string(&mut buf).context(fname));
+    file.read_to_string(&mut buf).context(fname)?;
     Ok(try!(buf.parse().context(fname)))
 }
 

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -33,7 +33,7 @@ fn parse_file() -> Result<u64, Error> {
     let mut file = File::open(fname).context(fname)?;
     let mut buf = String::new();
     file.read_to_string(&mut buf).context(fname)?;
-    Ok(try!(buf.parse().context(fname)))
+    Ok(buf.parse().context(fname)?)
 }
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,12 +228,12 @@
 //! }
 //!
 //! fn openfile(path: &Path) -> Result<(), Error> {
-//!     try!(File::open(path).context(path));
+//!     File::open(path).context(path)?;
 //!
 //!     // If we didn't have context, the line above would be written as;
 //!     //
-//!     // try!(File::open(path)
-//!     //     .map_err(|err| Error::File(path.to_path_buf(), err)));
+//!     // File::open(path)
+//!     //     .map_err(|err| Error::File(path.to_path_buf(), err))?;
 //!
 //!     Ok(())
 //! }
@@ -364,11 +364,11 @@ macro_rules! quick_error {
         $(#[$meta])*
         $($strdef)* $strname ( $internal );
 
-        impl ::std::fmt::Display for $strname {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter)
-                -> ::std::fmt::Result
+        impl ::core::fmt::Display for $strname {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter)
+                -> ::core::fmt::Result
             {
-                ::std::fmt::Display::fmt(&self.0, f)
+                ::core::fmt::Display::fmt(&self.0, f)
             }
         }
 
@@ -643,9 +643,9 @@ macro_rules! quick_error {
         #[allow(renamed_and_removed_lints)]
         #[allow(unused_doc_comment)]
         #[allow(unused_doc_comments)]
-        impl ::std::fmt::Display for $name {
-            fn fmt(&self, fmt: &mut ::std::fmt::Formatter)
-                -> ::std::fmt::Result
+        impl ::core::fmt::Display for $name {
+            fn fmt(&self, fmt: &mut ::core::fmt::Formatter)
+                -> ::core::fmt::Result
             {
                 match *self {
                     $(
@@ -712,17 +712,17 @@ macro_rules! quick_error {
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { display($self_:tt) -> ($( $exprs:tt )*) $( $tail:tt )*}
     ) => {
-        |quick_error!(IDENT $self_): &$name, f: &mut ::std::fmt::Formatter| { write!(f, $( $exprs )*) }
+        |quick_error!(IDENT $self_): &$name, f: &mut ::core::fmt::Formatter| { write!(f, $( $exprs )*) }
     };
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { display($pattern:expr) $( $tail:tt )*}
     ) => {
-        |_, f: &mut ::std::fmt::Formatter| { write!(f, $pattern) }
+        |_, f: &mut ::core::fmt::Formatter| { write!(f, $pattern) }
     };
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { display($pattern:expr, $( $exprs:tt )*) $( $tail:tt )*}
     ) => {
-        |_, f: &mut ::std::fmt::Formatter| { write!(f, $pattern, $( $exprs )*) }
+        |_, f: &mut ::core::fmt::Formatter| { write!(f, $pattern, $( $exprs )*) }
     };
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { $t:tt $( $tail:tt )*}
@@ -734,7 +734,7 @@ macro_rules! quick_error {
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { }
     ) => {
-        |self_: &$name, f: &mut ::std::fmt::Formatter| {
+        |self_: &$name, f: &mut ::core::fmt::Formatter| {
             write!(f, "{}", ::std::error::Error::description(self_))
         }
     };
@@ -1255,7 +1255,7 @@ mod test {
     #[test]
     fn parse_float_error() {
         fn parse_float(s: &str) -> Result<f32, ContextErr> {
-            Ok(try!(s.parse().context(s)))
+            Ok(s.parse().context(s)?)
         }
         assert_eq!(format!("{}", parse_float("12ab").unwrap_err()),
             r#"Float error "12ab": invalid float literal"#);
@@ -1264,7 +1264,7 @@ mod test {
     #[test]
     fn parse_int_error() {
         fn parse_int(s: &str) -> Result<i32, ContextErr> {
-            Ok(try!(s.parse().context(s)))
+            Ok(s.parse().context(s)?)
         }
         assert_eq!(format!("{}", parse_int("12.5").unwrap_err()),
             r#"Int error "12.5": invalid digit found in string"#);
@@ -1285,7 +1285,7 @@ mod test {
         fn parse_utf<P: AsRef<Path>>(s: &[u8], p: P)
             -> Result<(), ContextErr>
         {
-            try!(::std::str::from_utf8(s).context(p));
+            ::std::str::from_utf8(s).context(p)?;
             Ok(())
         }
         let etext = parse_utf(b"a\x80\x80", "/etc").unwrap_err().to_string();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,11 +364,11 @@ macro_rules! quick_error {
         $(#[$meta])*
         $($strdef)* $strname ( $internal );
 
-        impl ::core::fmt::Display for $strname {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter)
-                -> ::core::fmt::Result
+        impl ::std::fmt::Display for $strname {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter)
+                -> ::std::fmt::Result
             {
-                ::core::fmt::Display::fmt(&self.0, f)
+                ::std::fmt::Display::fmt(&self.0, f)
             }
         }
 
@@ -643,9 +643,9 @@ macro_rules! quick_error {
         #[allow(renamed_and_removed_lints)]
         #[allow(unused_doc_comment)]
         #[allow(unused_doc_comments)]
-        impl ::core::fmt::Display for $name {
-            fn fmt(&self, fmt: &mut ::core::fmt::Formatter)
-                -> ::core::fmt::Result
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, fmt: &mut ::std::fmt::Formatter)
+                -> ::std::fmt::Result
             {
                 match *self {
                     $(
@@ -712,17 +712,17 @@ macro_rules! quick_error {
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { display($self_:tt) -> ($( $exprs:tt )*) $( $tail:tt )*}
     ) => {
-        |quick_error!(IDENT $self_): &$name, f: &mut ::core::fmt::Formatter| { write!(f, $( $exprs )*) }
+        |quick_error!(IDENT $self_): &$name, f: &mut ::std::fmt::Formatter| { write!(f, $( $exprs )*) }
     };
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { display($pattern:expr) $( $tail:tt )*}
     ) => {
-        |_, f: &mut ::core::fmt::Formatter| { write!(f, $pattern) }
+        |_, f: &mut ::std::fmt::Formatter| { write!(f, $pattern) }
     };
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { display($pattern:expr, $( $exprs:tt )*) $( $tail:tt )*}
     ) => {
-        |_, f: &mut ::core::fmt::Formatter| { write!(f, $pattern, $( $exprs )*) }
+        |_, f: &mut ::std::fmt::Formatter| { write!(f, $pattern, $( $exprs )*) }
     };
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { $t:tt $( $tail:tt )*}
@@ -734,7 +734,7 @@ macro_rules! quick_error {
     (FIND_DISPLAY_IMPL $name:ident $item:ident: $imode:tt
         { }
     ) => {
-        |self_: &$name, f: &mut ::core::fmt::Formatter| {
+        |self_: &$name, f: &mut ::std::fmt::Formatter| {
             write!(f, "{}", ::std::error::Error::description(self_))
         }
     };


### PR DESCRIPTION
Uses edition 2018 and removes `try!`, as it's not available anymore in 2018.

With those changes it should be trivial to add no_std support as `core` can be used everywhere except in `std::error`.

cc #33 