### PR TITLE
Fix documentation link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Quick Error
 ===========
 
 :Status: production-ready
-:Documentation: http://tailhook.github.io/quick-error/
+:Documentation: https://docs.rs/quick-error/
 
 A macro which makes error types pleasant to write.
 


### PR DESCRIPTION
It now points to docs.rs. Linked site was not functional.