### PR TITLE
Visibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,13 +25,13 @@ Here is the comprehensive example:
             Io(err: io::Error) {
                 from()
                 display("I/O error: {}", err)
-                cause(err)
+                source(err)
             }
             Other(descr: &'static str) {
                 display("Error {}", descr)
             }
             IoAt { place: &'static str, err: io::Error } {
-                cause(err)
+                source(err)
                 display(me) -> ("io error at {}: {}", place, err)
                 from(s: String) -> {
                     place: "some string",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,9 +298,9 @@
 macro_rules! quick_error {
 
     (   $(#[$meta:meta])*
-        pub enum $name:ident { $($chunks:tt)* }
+        $v_name:vis enum $name:ident { $($chunks:tt)* }
     ) => {
-        quick_error!(SORT [pub enum $name $(#[$meta])* ]
+        quick_error!(SORT [$v_name enum $name $(#[$meta])* ]
             items [] buf []
             queue [ $($chunks)* ]);
     };
@@ -313,19 +313,19 @@ macro_rules! quick_error {
     };
 
     (   $(#[$meta:meta])*
-        pub enum $name:ident wraps $enum_name:ident { $($chunks:tt)* }
+        $v_name:vis enum $name:ident wraps $enum_name:ident { $($chunks:tt)* }
     ) => {
-        quick_error!(WRAPPER $enum_name [ pub struct ] $name $(#[$meta])*);
+        quick_error!(WRAPPER $enum_name [ $v_name struct ] $name $(#[$meta])*);
         quick_error!(SORT [enum $enum_name $(#[$meta])* ]
             items [] buf []
             queue [ $($chunks)* ]);
     };
 
     (   $(#[$meta:meta])*
-        pub enum $name:ident wraps pub $enum_name:ident { $($chunks:tt)* }
+        $v_name:vis enum $name:ident wraps $v_enum_name:vis $enum_name:ident { $($chunks:tt)* }
     ) => {
-        quick_error!(WRAPPER $enum_name [ pub struct ] $name $(#[$meta])*);
-        quick_error!(SORT [pub enum $enum_name $(#[$meta])* ]
+        quick_error!(WRAPPER $enum_name [ $v_name struct ] $name $(#[$meta])*);
+        quick_error!(SORT [$v_enum_name enum $enum_name $(#[$meta])* ]
             items [] buf []
             queue [ $($chunks)* ]);
     };
@@ -339,10 +339,10 @@ macro_rules! quick_error {
     };
 
     (   $(#[$meta:meta])*
-        enum $name:ident wraps pub $enum_name:ident { $($chunks:tt)* }
+        enum $name:ident wraps $v_enum_name:vis $enum_name:ident { $($chunks:tt)* }
     ) => {
         quick_error!(WRAPPER $enum_name [ struct ] $name $(#[$meta])*);
-        quick_error!(SORT [pub enum $enum_name $(#[$meta])* ]
+        quick_error!(SORT [$v_enum_name enum $enum_name $(#[$meta])* ]
             items [] buf []
             queue [ $($chunks)* ]);
     };
@@ -396,14 +396,14 @@ macro_rules! quick_error {
             quick_error!(ERROR_CHECK $imode $($ifuncs)*);
         )*
     };
-    (SORT [pub enum $name:ident $( #[$meta:meta] )*]
+    (SORT [$v_name:vis enum $name:ident $( #[$meta:meta] )*]
         items [$($( #[$imeta:meta] )*
                   => $iitem:ident: $imode:tt [$( $ivar:ident: $ityp:ty ),*]
                                 {$( $ifuncs:tt )*} )* ]
         buf [ ]
         queue [ ]
     ) => {
-        quick_error!(ENUM_DEFINITION [pub enum $name $( #[$meta] )*]
+        quick_error!(ENUM_DEFINITION [$v_name enum $name $( #[$meta] )*]
             body []
             queue [$($( #[$imeta] )*
                       => $iitem: $imode [$( $ivar: $ityp ),*] )*]
@@ -544,7 +544,7 @@ macro_rules! quick_error {
             queue [ ]);
     };
     // Public enum (Queue Empty)
-    (ENUM_DEFINITION [pub enum $name:ident $( #[$meta:meta] )*]
+    (ENUM_DEFINITION [$v_name:vis enum $name:ident $( #[$meta:meta] )*]
         body [$($( #[$imeta:meta] )*
             => $iitem:ident ($(($( $ttyp:ty ),+))*) {$({$( $svar:ident: $styp:ty ),*})*} )* ]
         queue [ ]
@@ -554,7 +554,7 @@ macro_rules! quick_error {
         #[allow(unused_doc_comment)]
         #[allow(unused_doc_comments)]
         $(#[$meta])*
-        pub enum $name {
+        $v_name enum $name {
             $(
                 $(#[$imeta])*
                 $iitem $(($( $ttyp ),+))* $({$( $svar: $styp ),*})*,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -997,7 +997,7 @@ mod test {
 
     #[test]
     fn bare_item_trait() {
-        let err: &Error = &Bare::Two;
+        let err: &dyn Error = &Bare::Two;
         assert_eq!(format!("{}", err), "Two".to_string());
         assert_eq!(format!("{:?}", err), "Two".to_string());
         assert!(err.source().is_none());
@@ -1075,7 +1075,7 @@ mod test {
     #[test]
     fn tuple_wrapper_trait_str() {
         let desc = "hello";
-        let err: &Error = &TupleWrapper::Other(desc);
+        let err: &dyn Error = &TupleWrapper::Other(desc);
         assert_eq!(format!("{}", err), format!("Error: {}", desc));
         assert_eq!(format!("{:?}", err), format!("Other({:?})", desc));
         assert!(err.source().is_none());
@@ -1087,7 +1087,7 @@ mod test {
         let source = String::from_utf8(invalid_utf8.clone())
             .unwrap_err()
             .utf8_error();
-        let err: &Error = &TupleWrapper::FromUtf8Error(source.clone(), invalid_utf8.clone());
+        let err: &dyn Error = &TupleWrapper::FromUtf8Error(source.clone(), invalid_utf8.clone());
         assert_eq!(
             format!("{}", err),
             format!(
@@ -1162,7 +1162,7 @@ mod test {
         let source = String::from_utf8(invalid_utf8.clone())
             .unwrap_err()
             .utf8_error();
-        let err: &Error = &StructWrapper::Utf8Error {
+        let err: &dyn Error = &StructWrapper::Utf8Error {
             err: source.clone(),
             hint: Some("nonsense"),
         };
@@ -1309,7 +1309,7 @@ mod test {
         let cause = String::from_utf8(invalid_utf8.clone())
             .unwrap_err()
             .utf8_error();
-        let err: &Error = &StructWrapper::Utf8Error {
+        let err: &dyn Error = &StructWrapper::Utf8Error {
             err: cause.clone(),
             hint: Some("nonsense"),
         };


### PR DESCRIPTION
Fixes #48.

This however requires changes to the MSRV, in particular Rust 1.30 is required. However I am not even sure whether `quick-error` has a MSRV rule.

Also this PR doesn't include a test because I am not exactly sure how to test this because it's not possible (to my knowledge) to do something like `#[should_fail]`.