### PR TITLE
Improve README and fix compile warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,13 +25,13 @@ Here is the comprehensive example:
             Io(err: io::Error) {
                 from()
                 display("I/O error: {}", err)
-                cause(err)
+                source(err)
             }
             Other(descr: &'static str) {
                 display("Error {}", descr)
             }
             IoAt { place: &'static str, err: io::Error } {
-                cause(err)
+                source(err)
                 display(me) -> ("io error at {}: {}", place, err)
                 from(s: String) -> {
                     place: "some string",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -997,7 +997,7 @@ mod test {
 
     #[test]
     fn bare_item_trait() {
-        let err: &Error = &Bare::Two;
+        let err: &dyn Error = &Bare::Two;
         assert_eq!(format!("{}", err), "Two".to_string());
         assert_eq!(format!("{:?}", err), "Two".to_string());
         assert!(err.source().is_none());
@@ -1075,7 +1075,7 @@ mod test {
     #[test]
     fn tuple_wrapper_trait_str() {
         let desc = "hello";
-        let err: &Error = &TupleWrapper::Other(desc);
+        let err: &dyn Error = &TupleWrapper::Other(desc);
         assert_eq!(format!("{}", err), format!("Error: {}", desc));
         assert_eq!(format!("{:?}", err), format!("Other({:?})", desc));
         assert!(err.source().is_none());
@@ -1087,7 +1087,7 @@ mod test {
         let source = String::from_utf8(invalid_utf8.clone())
             .unwrap_err()
             .utf8_error();
-        let err: &Error = &TupleWrapper::FromUtf8Error(source.clone(), invalid_utf8.clone());
+        let err: &dyn Error = &TupleWrapper::FromUtf8Error(source.clone(), invalid_utf8.clone());
         assert_eq!(
             format!("{}", err),
             format!(
@@ -1162,7 +1162,7 @@ mod test {
         let source = String::from_utf8(invalid_utf8.clone())
             .unwrap_err()
             .utf8_error();
-        let err: &Error = &StructWrapper::Utf8Error {
+        let err: &dyn Error = &StructWrapper::Utf8Error {
             err: source.clone(),
             hint: Some("nonsense"),
         };
@@ -1276,9 +1276,7 @@ mod test {
 
     #[test]
     fn path_context() {
-        fn parse_utf<P: AsRef<Path>>(s: &[u8], p: P)
-            -> Result<(), ContextErr>
-        {
+        fn parse_utf<P: AsRef<Path>>(s: &[u8], p: P) -> Result<(), ContextErr> {
             ::std::str::from_utf8(s).context(p)?;
             Ok(())
         }
@@ -1309,7 +1307,7 @@ mod test {
         let cause = String::from_utf8(invalid_utf8.clone())
             .unwrap_err()
             .utf8_error();
-        let err: &Error = &StructWrapper::Utf8Error {
+        let err: &dyn Error = &StructWrapper::Utf8Error {
             err: cause.clone(),
             hint: Some("nonsense"),
         };


### PR DESCRIPTION
This PR is merely a side-effect of me looking into why my program couldn't display causes using `anyhow`, so the output looked like this:

<img width="592" alt="Screenshot 2020-07-17 at 14 21 00" src="https://user-images.githubusercontent.com/63622/87756102-de369980-c83a-11ea-93e7-02855522cf28.png">

A quick investigation showed that anyhow [was using the `source()`](https://github.com/dtolnay/anyhow/blob/60c88bc53c250f7b1205a65a59fc210dbe10e9f8/src/chain.rs#L41) method, whereas I and quick-error 1.2.3 still use the now _deprecated_ `cause()` method.

After cloning the main branch of `quick-error`, I thought it should be possible to add `source()` support in a non-breaking fashion. To my surprise, it was already added while removing support for `cause()`. After migrating by replacing `cause(err)` with `source(err)` and `description(…)` with `display(…)` all worked as expected and I could witness the error chain I always wanted:

<img width="797" alt="Screenshot 2020-07-17 at 14 27 24" src="https://user-images.githubusercontent.com/63622/87756348-5bfaa500-c83b-11ea-894e-bfbf8c0ae826.png">

**Would it be possible to get a 2.0 release to crates.io?**

_Alternatively_, maybe it's preferred to restore backwards compatibility instead, and I am willing to contribute. Please let me know :), and thanks for your help!


##### PS

`quick-error` absolutely has its place in the current error landscape as it is has easy-to-remember syntax and adds only neglectable compile time, while producing minimal error enums suitable for use in library crates. `thiserror` does something similar, but adds considerable compile time as it's a proc-macro.