### PR TITLE
Allow the `extra_unused_lifetimes` lint in the context impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -823,6 +823,7 @@ macro_rules! quick_error {
         { context($cvar:ident: $ctyp:ty, $fvar:ident: $ftyp:ty)
             -> ($( $texpr:expr ),*) $( $tail:tt )* }
     ) => {
+        #[allow(extra_unused_lifetimes)]
         impl<'a> From<$crate::Context<$ctyp, $ftyp>> for $name {
             fn from(
                 $crate::Context($cvar, $fvar): $crate::Context<$ctyp, $ftyp>)


### PR DESCRIPTION
Hi!

In the uutils/coreutils repository, we ran into this issue: https://github.com/uutils/coreutils/pull/3687. The minimum reproducible case is:
```rust
quick_error! {
    #[derive(Debug)]
    enum Error {
        SomeError(s: String, err: io::Error) {
            context(s: String, err: io::Error) -> (s, err)
        }
    }
}
```

and then running `cargo clippy -- -D warnings`. In this case, an impl is generated with the lifetime  `'a`, which is not used, since all the arguments to the `context` are owned, which triggers the clippy lint.

This might be a fairly niche issue, since we treat clippy warnings as errors, but it would still be nice to fix this upstream. Allowing the lint on the context impl fixed the issue.

Edit: I should probably mention that we started seeing this problem with Rust 1.62.