### PR TITLE
Forbid unsafe_code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 //! A macro which makes errors easy to write
 //!


### PR DESCRIPTION
This crate already uses fully safe code so this PR adds an annotation enforcing that at compile time.

Looking for #![forbid(unsafe_code)] is more reliable than trying to grep the crate source code for instances of "unsafe", since the latter could hypothetically be concealed by macros and such.